### PR TITLE
refactor: unify Cookie API to return string and map[string]string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING**: `Cookie()` return type changed from `*fasthttp.Cookie` to `string`
+- **BREAKING**: `Cookies()` return type changed from `[]*fasthttp.Cookie` to `map[string]string`
+
+### Fixed
+
+- Fixed dangling pointer bug in internal `cookie()` method
+
 ## [0.9.0] - Apr 1, 2026
 
 ### Added

--- a/context.go
+++ b/context.go
@@ -297,13 +297,13 @@ func (c *Context) DelHeader(key string) {
 	c.res.delHeader(key)
 }
 
-// Cookie returns the cookie with the given name.
-func (c *Context) Cookie(name string) *fasthttp.Cookie {
+// Cookie returns the cookie value with the given name.
+func (c *Context) Cookie(name string) string {
 	return c.req.cookie(name)
 }
 
 // Cookies returns all cookies from the request.
-func (c *Context) Cookies() []*fasthttp.Cookie {
+func (c *Context) Cookies() map[string]string {
 	return c.req.cookies()
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -613,10 +613,8 @@ func TestCookie(t *testing.T) {
 	c.ctx.Request.Header.SetCookie("test", "value")
 
 	cookie := c.Cookie("test")
-	if cookie != nil {
-		if string(cookie.Key()) != "test" {
-			t.Errorf("Expected cookie key 'test', got '%s'", string(cookie.Key()))
-		}
+	if cookie != "value" {
+		t.Errorf("Expected cookie value 'value', got '%s'", cookie)
 	}
 }
 
@@ -624,8 +622,8 @@ func TestCookieNotFound(t *testing.T) {
 	c, _ := createTestContext("GET", "/path", nil)
 
 	cookie := c.Cookie("nonexistent")
-	if cookie != nil {
-		t.Errorf("Expected nil for nonexistent cookie, got %v", cookie)
+	if cookie != "" {
+		t.Errorf("Expected empty string for nonexistent cookie, got '%s'", cookie)
 	}
 }
 
@@ -996,8 +994,14 @@ func TestContext_Cookies(t *testing.T) {
 	c.req = newRequest(ctx)
 
 	cookies := c.Cookies()
-	if len(cookies) == 0 {
-		t.Error("Expected cookies to be non-empty")
+	if len(cookies) != 2 {
+		t.Errorf("Expected 2 cookies, got %d", len(cookies))
+	}
+	if cookies["session"] != "abc" {
+		t.Errorf("Expected session value 'abc', got '%s'", cookies["session"])
+	}
+	if cookies["theme"] != "dark" {
+		t.Errorf("Expected theme value 'dark', got '%s'", cookies["theme"])
 	}
 }
 
@@ -1557,8 +1561,8 @@ func TestContext_CookieNotFound(t *testing.T) {
 	c, _ := createTestContext("GET", "/test", nil)
 
 	cookie := c.Cookie("nonexistent")
-	if cookie != nil {
-		t.Errorf("Expected nil for nonexistent cookie, got %v", cookie)
+	if cookie != "" {
+		t.Errorf("Expected empty string for nonexistent cookie, got '%s'", cookie)
 	}
 }
 

--- a/examples/cookie/app.go
+++ b/examples/cookie/app.go
@@ -11,13 +11,13 @@ func main() {
 
 	app.Get("/ping", func(ctx *lightning.Context) {
 		cookie := ctx.Cookie("sid")
-		if cookie != nil {
-			fmt.Println(string(cookie.Key()), string(cookie.Value()))
+		if cookie != "" {
+			fmt.Println("sid", cookie)
 		}
 
 		cookies := ctx.Cookies()
-		for _, c := range cookies {
-			fmt.Println(string(c.Key()), string(c.Value()))
+		for name, value := range cookies {
+			fmt.Println(name, value)
 		}
 
 		ctx.SetCookie("sid", "sid:xxxxxxxxxx")

--- a/request.go
+++ b/request.go
@@ -55,23 +55,14 @@ func (r *request) headers() map[string]string {
 	return headers
 }
 
-func (r *request) cookie(name string) *fasthttp.Cookie {
-	var cookie fasthttp.Cookie
-	cookie.ParseBytes(r.ctx.Request.Header.Cookie(name))
-	if len(cookie.Key()) > 0 {
-		return &cookie
-	}
-	return nil
+func (r *request) cookie(name string) string {
+	return string(r.ctx.Request.Header.Cookie(name))
 }
 
-func (r *request) cookies() []*fasthttp.Cookie {
-	var cookies []*fasthttp.Cookie
-	r.ctx.Request.Header.VisitAll(func(key, value []byte) {
-		if string(key) == "Cookie" {
-			var c fasthttp.Cookie
-			c.ParseBytes(value)
-			cookies = append(cookies, &c)
-		}
+func (r *request) cookies() map[string]string {
+	cookies := make(map[string]string)
+	r.ctx.Request.Header.VisitAllCookie(func(key, value []byte) {
+		cookies[string(key)] = string(value)
 	})
 	return cookies
 }

--- a/request_test.go
+++ b/request_test.go
@@ -23,13 +23,13 @@ func TestRequest_Cookie(t *testing.T) {
 	r := newRequest(ctx)
 
 	cookie := r.cookie("cookie1")
-	if cookie != nil && string(cookie.Key()) != "cookie1" {
-		t.Errorf("Expected cookie key 'cookie1', got '%s'", string(cookie.Key()))
+	if cookie != "value1" {
+		t.Errorf("Expected cookie value 'value1', got '%s'", cookie)
 	}
 
 	cookie = r.cookie("nonexistent")
-	if cookie != nil {
-		t.Errorf("Expected nil for nonexistent cookie, got %v", cookie)
+	if cookie != "" {
+		t.Errorf("Expected empty string for nonexistent cookie, got '%s'", cookie)
 	}
 }
 
@@ -43,8 +43,14 @@ func TestRequest_Cookies(t *testing.T) {
 	r := newRequest(ctx)
 	cookies := r.cookies()
 
-	if len(cookies) == 0 {
-		t.Error("Expected cookies, got empty")
+	if len(cookies) != 2 {
+		t.Errorf("Expected 2 cookies, got %d", len(cookies))
+	}
+	if cookies["cookie1"] != "value1" {
+		t.Errorf("Expected cookie1 value 'value1', got '%s'", cookies["cookie1"])
+	}
+	if cookies["cookie2"] != "value2" {
+		t.Errorf("Expected cookie2 value 'value2', got '%s'", cookies["cookie2"])
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR unifies the Cookie API to align with the framework's design style.

## Breaking Changes

- `Cookie()` return type changed from `*fasthttp.Cookie` to `string`
- `Cookies()` return type changed from `[]*fasthttp.Cookie` to `map[string]string`

## Bug Fixes

- Fixed dangling pointer bug in internal `cookie()` method

## API Changes

### Before
```go
cookie := ctx.Cookie("sid")
if cookie != nil {
    value := string(cookie.Value())
}

for _, c := range ctx.Cookies() {
    fmt.Println(string(c.Key()), string(c.Value()))
}
```

### After
```go
value := ctx.Cookie("sid")
if value != "" {
    // use value
}

for name, value := range ctx.Cookies() {
    fmt.Println(name, value)
}
```

## Benefits

1. No longer exposes underlying `fasthttp` types
2. Consistent with other framework methods (Query, Param, Header)
3. Simpler usage, no nil checks needed
4. Fixed memory safety bug
